### PR TITLE
Add orders relation to Offer model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,7 @@ model Offer {
   creatorId  String?
   creator    User?        @relation(fields: [creatorId], references: [id])
   reviews    Review[]     @relation("OfferReviews")
+  orders     Order[]
 
   @@index([createdAt])
 }


### PR DESCRIPTION
## Purpose
Based on the conversation context, the user requested to continue with database schema modifications, specifically adding relationship connections between models.

## Code changes
- Added `orders` field to the `Offer` model in Prisma schema
- Established one-to-many relationship between `Offer` and `Order` models
- This allows tracking which orders are associated with each offerTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5cb82fe43264467685e68af6109cdbd3/curry-lab)

👀 [Preview Link](https://5cb82fe43264467685e68af6109cdbd3-curry-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5cb82fe43264467685e68af6109cdbd3</projectId>-->
<!--<branchName>curry-lab</branchName>-->